### PR TITLE
Disable npm strict-ssl for ci build

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -90,5 +90,5 @@ quarkus:
     package-manager-command:
       install-env:
         strict-ssl: false
-      install: "npm ci"
+      install: "npm config set strict-ssl false && npm ci"
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,7 +62,7 @@ quarkus:
     package-manager-command:
       install-env:
         strict-ssl: false
-      install: "npm ci"
+      install: "npm config set strict-ssl false && npm ci"
 
 
 indy_security:
@@ -98,4 +98,4 @@ indy_security:
           max-file-size: 10M
     quinoa:
       package-manager-command:
-        install: "npm ci"
+        install: "npm config set strict-ssl false && npm ci"


### PR DESCRIPTION
  We're using a registry proxy in ci system, so need to disable ssl for
  npm build