### PR TITLE
Fix content listing issue

### DIFF
--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/GenericContentAccessResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/GenericContentAccessResource.java
@@ -15,8 +15,11 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
+import org.commonjava.indy.service.ui.client.content.ContentBrowseServiceClient;
 import org.commonjava.indy.service.ui.client.content.GenericContentAccessServiceClient;
+import org.commonjava.indy.service.ui.models.content.ContentBrowseResult;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
+import org.commonjava.indy.service.ui.util.PackageTypeConstants;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -55,6 +58,10 @@ public class GenericContentAccessResource
     @Inject
     @RestClient
     GenericContentAccessServiceClient client;
+
+    @Inject
+    @RestClient
+    ContentBrowseServiceClient browseClient;
 
     @Operation( description = "Store content under the given artifact store (type/name) and path." )
     @Parameters( { @Parameter( name = "type", in = PATH, description = "The type of the repository.",
@@ -130,6 +137,15 @@ public class GenericContentAccessResource
                            final @PathParam( "path" ) String path, @Context final UriInfo uriInfo,
                            @Context final HttpServletRequest request )
     {
+        if ( path.trim().endsWith( "/" ) )
+        {
+            try (Response r = browseClient.browseDirectory( PackageTypeConstants.PKG_TYPE_GENERIC_HTTP, type, name,
+                                                            path, uriInfo ))
+            {
+                ContentBrowseResult result = r.readEntity( ContentBrowseResult.class );
+                return Response.ok( result ).build();
+            }
+        }
         return client.doGet( type, name, path, uriInfo, request );
     }
 

--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/MavenContentAccessResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/MavenContentAccessResource.java
@@ -15,8 +15,11 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
+import org.commonjava.indy.service.ui.client.content.ContentBrowseServiceClient;
 import org.commonjava.indy.service.ui.client.content.MavenContentAccessServiceClient;
+import org.commonjava.indy.service.ui.models.content.ContentBrowseResult;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
+import org.commonjava.indy.service.ui.util.PackageTypeConstants;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -56,6 +59,10 @@ public class MavenContentAccessResource
     @Inject
     @RestClient
     MavenContentAccessServiceClient client;
+
+    @Inject
+    @RestClient
+    ContentBrowseServiceClient browseClient;
 
     @Operation( description = "Store Maven artifact content under the given artifact store (type/name) and path." )
     @Parameters( { @Parameter( name = "type", in = PATH, description = "The type of the repository.",
@@ -143,6 +150,15 @@ public class MavenContentAccessResource
         //        return builder.build();
         //        System.out.println(response.getHeaders());
         //        return response;
+        if ( path.trim().endsWith( "/" ) )
+        {
+            try (Response r = browseClient.browseDirectory( PackageTypeConstants.PKG_TYPE_GENERIC_HTTP, type, name,
+                                                            path, uriInfo ))
+            {
+                ContentBrowseResult result = r.readEntity( ContentBrowseResult.class );
+                return Response.ok( result ).build();
+            }
+        }
         return client.doGet( type, name, path, uriInfo, request );
     }
 

--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/diag/DiagnosticsResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/diag/DiagnosticsResource.java
@@ -40,7 +40,7 @@ public class DiagnosticsResource
 {
     @Inject
     @RestClient
-    private DiagnosticsServiceClient client;
+    DiagnosticsServiceClient client;
 
     @Operation( description = "Retrieve a thread dump for Indy." )
     @APIResponse( responseCode = "200", description = "Thread dump content" )

--- a/src/main/java/org/commonjava/indy/service/ui/util/PackageTypeConstants.java
+++ b/src/main/java/org/commonjava/indy/service/ui/util/PackageTypeConstants.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc. (https://github.com/Commonjava/indy-ui-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.ui.util;
+
+public class PackageTypeConstants
+{
+    public static final String PKG_TYPE_MAVEN = "maven";
+
+    public static final String PKG_TYPE_NPM = "npm";
+
+    public static final String PKG_TYPE_GENERIC_HTTP = "generic-http";
+
+    public static boolean isValidPackageType( final String pkgType )
+    {
+        return PKG_TYPE_MAVEN.equals( pkgType ) || PKG_TYPE_NPM.equals( pkgType ) || PKG_TYPE_GENERIC_HTTP.equals(
+                pkgType );
+    }
+}


### PR DESCRIPTION
For all content path endswith "/" for maven and generic-http,
consider them as content browse listing requests and use content
browse client to handle
