### PR TITLE
Fix content listing content issue

### DIFF
--- a/src/main/java/org/commonjava/indy/service/ui/client/content/ContentBrowseReGenClient.java
+++ b/src/main/java/org/commonjava/indy/service/ui/client/content/ContentBrowseReGenClient.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc. (https://github.com/Commonjava/indy-ui-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.ui.client.content;
+
+import org.commonjava.indy.service.ui.models.content.ContentBrowseResult;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.commonjava.indy.service.ui.util.UrlUtils.replaceHostInUrl;
+
+@ApplicationScoped
+public class ContentBrowseReGenClient
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    @Inject
+    @RestClient
+    ContentBrowseServiceClient client;
+
+    public Response headForDirectory( final String packageType, String type, final String name, String path )
+    {
+        return client.headForDirectory( packageType, type, name, path );
+    }
+
+    public Response browseDirectory( final String packageType, String type, final String name, String path,
+                                     final UriInfo uriInfo )
+    {
+        try (Response r = client.browseDirectory( packageType, type, name, path, uriInfo ))
+        {
+            return doResponse( r, uriInfo );
+        }
+    }
+
+    public Response browseRoot( final String packageType, String type, final String name, final UriInfo uriInfo )
+    {
+        try (Response r = client.browseRoot( packageType, type, name, uriInfo ))
+        {
+            return doResponse( r, uriInfo );
+        }
+    }
+
+    public Response doResponse( final Response original, final UriInfo uriInfo )
+    {
+        Response.ResponseBuilder newRes = Response.fromResponse( original );
+        ContentBrowseResult result = original.readEntity( ContentBrowseResult.class );
+        final String localHost = uriInfo.getBaseUri().getHost();
+        final int localPort = uriInfo.getBaseUri().getPort();
+        final String newHost =
+                localPort != 80 && localPort != 443 ? String.format( "%s:%s", localHost, localPort ) : localHost;
+        logger.warn( "Base Host:{}", newHost );
+        if ( isNotBlank( result.getParentUrl() ) )
+        {
+            result.setParentUrl( replaceHostInUrl( result.getParentUrl(), newHost ) );
+        }
+        if ( isNotBlank( result.getBaseBrowseUrl() ) )
+        {
+            result.setBaseBrowseUrl( replaceHostInUrl( result.getBaseBrowseUrl(), newHost ) );
+        }
+        if ( isNotBlank( result.getBaseContentUrl() ) )
+        {
+            result.setBaseContentUrl( replaceHostInUrl( result.getBaseContentUrl(), newHost ) );
+        }
+        if ( isNotBlank( result.getStoreBrowseUrl() ) )
+        {
+            result.setStoreBrowseUrl( replaceHostInUrl( result.getStoreBrowseUrl(), newHost ) );
+        }
+        if ( isNotBlank( result.getStoreContentUrl() ) )
+        {
+            result.setStoreContentUrl( replaceHostInUrl( result.getStoreContentUrl(), newHost ) );
+        }
+        if ( result.getSources() != null && !result.getSources().isEmpty() )
+        {
+            result.setSources( result.getSources()
+                                     .stream()
+                                     .map( s -> replaceHostInUrl( s, newHost ) )
+                                     .collect( Collectors.toList() ) );
+        }
+        if ( result.getListingUrls() != null && !result.getListingUrls().isEmpty() )
+        {
+            for ( ContentBrowseResult.ListingURLResult listResult : result.getListingUrls() )
+            {
+                listResult.setListingUrl( replaceHostInUrl( listResult.getListingUrl(), newHost ) );
+            }
+        }
+        return newRes.entity( result ).build();
+    }
+
+}

--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/ContentBrowseResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/ContentBrowseResource.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
+import org.commonjava.indy.service.ui.client.content.ContentBrowseReGenClient;
 import org.commonjava.indy.service.ui.client.content.ContentBrowseServiceClient;
 import org.commonjava.indy.service.ui.models.content.ContentBrowseResult;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
@@ -50,8 +51,7 @@ public class ContentBrowseResource
     private final Logger logger = LoggerFactory.getLogger( this.getClass() );
 
     @Inject
-    @RestClient
-    ContentBrowseServiceClient client;
+    ContentBrowseReGenClient client;
 
     @Operation(
             description = "Retrieve directory content under the given artifact store (type/name) and directory path." )
@@ -95,13 +95,7 @@ public class ContentBrowseResource
                                      final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                                      final @PathParam( "path" ) String path, @Context final UriInfo uriInfo )
     {
-        try (Response r = client.browseDirectory( packageType, type, name, path, uriInfo ))
-        {
-            ContentBrowseResult result = r.readEntity( ContentBrowseResult.class );
-            logger.debug( "Returning: {}", result );
-            return Response.ok( result ).build();
-        }
-
+        return client.browseDirectory( packageType, type, name, path, uriInfo );
     }
 
     @Operation( description = "Retrieve root listing under the given artifact store (type/name)." )
@@ -121,12 +115,7 @@ public class ContentBrowseResource
                                 final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                                 @Context final UriInfo uriInfo )
     {
-        try (Response r = client.browseRoot( packageType, type, name, uriInfo ))
-        {
-            ContentBrowseResult result = r.readEntity( ContentBrowseResult.class );
-            logger.debug( "{}", result );
-            return Response.ok( result ).build();
-        }
+        return client.browseRoot( packageType, type, name, uriInfo );
     }
 
 }

--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/GenericContentAccessResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/GenericContentAccessResource.java
@@ -15,11 +15,8 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
-import org.commonjava.indy.service.ui.client.content.ContentBrowseServiceClient;
 import org.commonjava.indy.service.ui.client.content.GenericContentAccessServiceClient;
-import org.commonjava.indy.service.ui.models.content.ContentBrowseResult;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
-import org.commonjava.indy.service.ui.util.PackageTypeConstants;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -58,10 +55,6 @@ public class GenericContentAccessResource
     @Inject
     @RestClient
     GenericContentAccessServiceClient client;
-
-    @Inject
-    @RestClient
-    ContentBrowseServiceClient browseClient;
 
     @Operation( description = "Store content under the given artifact store (type/name) and path." )
     @Parameters( { @Parameter( name = "type", in = PATH, description = "The type of the repository.",
@@ -137,14 +130,15 @@ public class GenericContentAccessResource
                            final @PathParam( "path" ) String path, @Context final UriInfo uriInfo,
                            @Context final HttpServletRequest request )
     {
-        if ( path.trim().endsWith( "/" ) )
+        if ( uriInfo.getAbsolutePath().toString().trim().endsWith( "/" ) )
         {
-            try (Response r = browseClient.browseDirectory( PackageTypeConstants.PKG_TYPE_GENERIC_HTTP, type, name,
-                                                            path, uriInfo ))
-            {
-                ContentBrowseResult result = r.readEntity( ContentBrowseResult.class );
-                return Response.ok( result ).build();
-            }
+            return Response.seeOther( uriInfo.getBaseUriBuilder()
+                                             .path( "browse/generic-http" )
+                                             .path( type )
+                                             .path( name )
+                                             .path( path )
+                                             .build() ).build();
+
         }
         return client.doGet( type, name, path, uriInfo, request );
     }
@@ -163,7 +157,8 @@ public class GenericContentAccessResource
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            @Context final UriInfo uriInfo, @Context final HttpServletRequest request )
     {
-        return client.doGet( type, name, uriInfo, request );
+        return Response.seeOther(
+                uriInfo.getBaseUriBuilder().path( "browse/generic-http" ).path( type ).path( name ).build() ).build();
     }
 
 }

--- a/src/main/java/org/commonjava/indy/service/ui/util/UrlUtils.java
+++ b/src/main/java/org/commonjava/indy/service/ui/util/UrlUtils.java
@@ -17,9 +17,12 @@ package org.commonjava.indy.service.ui.util;
 
 import java.io.ByteArrayOutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 
 public final class UrlUtils
@@ -152,6 +155,23 @@ public final class UrlUtils
     public static String uriDecode( String source )
     {
         return uriDecode( source, null );
+    }
+
+    public static String replaceHostInUrl( String originalURL, String newHost )
+
+    {
+        try
+        {
+            URI uri = new URI( originalURL );
+            uri = new URI( uri.getScheme().toLowerCase( Locale.US ), newHost, uri.getPath(), uri.getQuery(),
+                           uri.getFragment() );
+
+            return uri.toString();
+        }
+        catch ( URISyntaxException e )
+        {
+            return originalURL;
+        }
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,11 +7,11 @@ quarkus:
     enable-compression: true
     limits:
       max-body-size: 500M
-    auth:
-      permission:
-        authenticated:
-          paths: "/*"
-          policy: authenticated
+#    auth:
+#      permission:
+#        authenticated:
+#          paths: "/*"
+#          policy: authenticated
   package:
     type: uber-jar
   resteasy:
@@ -21,6 +21,12 @@ quarkus:
   keycloak:
     devservices:
       enabled: false
+  oidc:
+    enabled: true
+    auth-server-url: "http://localhost:8080/realms/pncredhat"
+  security:
+    auth:
+      enabled-in-dev-mode: false
   log:
     level: INFO
     min-level: TRACE

--- a/src/test/java/org/commonjava/indy/service/ui/util/UrlUtilsTest.java
+++ b/src/test/java/org/commonjava/indy/service/ui/util/UrlUtilsTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc. (https://github.com/Commonjava/indy-ui-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.ui.util;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+import static org.commonjava.indy.service.ui.util.UrlUtils.replaceHostInUrl;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlUtilsTest
+{
+    @Test
+    public void testReplaceHostInUrl()
+    {
+        final String url =
+                "http://indy.indy.svc.cluster.local/api/browse/maven/remote/koji-c3p0-0.9.1.2-10_redhat_3.ep6.el6";
+
+        assertThat( replaceHostInUrl( url, "localhost:8080" ), CoreMatchers.equalTo(
+                "http://localhost:8080/api/browse/maven/remote/koji-c3p0-0.9.1.2-10_redhat_3.ep6.el6" ) );
+    }
+}


### PR DESCRIPTION
  The content browse api returned from main indy contains urls, which
  points to the original indy content host. This is not accessible from
  the unique ui service, so need to replace the url to the ui service
  ones.