### PR TITLE
Set opentelemetry to true for build time

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ quarkus:
   security:
     auth:
       enabled-in-dev-mode: false
+  opentelemetry:
+    enabled: true
   log:
     level: INFO
     min-level: TRACE
@@ -61,8 +63,6 @@ quarkus:
   swagger-ui:
     always-include: true
     title: "Indy"
-  opentelemetry:
-    enabled: false
 
   quinoa:
     # ui-dir: "webui"


### PR DESCRIPTION
  Seems the opentelemetry.enabled is a build time config, we need to set
  it to true to make it work in runtime