### PR TITLE
[cherry-pick] Disable http compression

### DIFF
--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/GenericContentAccessResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/GenericContentAccessResource.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
+import io.quarkus.vertx.http.Uncompressed;
 import org.commonjava.indy.service.ui.client.content.GenericContentAccessServiceClient;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -105,6 +106,7 @@ public class GenericContentAccessResource
                           description = "Header metadata for content (or rendered listing when path ends with '/index.html' or '/'" ), } )
     @HEAD
     @Path( "/{path: (.*)}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doHead( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                             final @PathParam( "path" ) String path,
                             @QueryParam( CHECK_CACHE_ONLY ) final Boolean cacheOnly, @Context final UriInfo uriInfo,
@@ -126,6 +128,7 @@ public class GenericContentAccessResource
                           description = "Rendered content listing (when path ends with '/index.html' or '/') or Content stream" ) } )
     @GET
     @Path( "/{path: (.*)}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            final @PathParam( "path" ) String path, @Context final UriInfo uriInfo,
                            @Context final HttpServletRequest request )
@@ -154,6 +157,7 @@ public class GenericContentAccessResource
                   description = "Rendered content listing or Content stream" )
     @GET
     @Path( "/" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            @Context final UriInfo uriInfo, @Context final HttpServletRequest request )
     {

--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/MavenContentAccessResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/MavenContentAccessResource.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
+import io.quarkus.vertx.http.Uncompressed;
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.service.ui.client.content.MavenContentAccessServiceClient;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
@@ -111,6 +112,7 @@ public class MavenContentAccessResource
                           description = "Header metadata for content (or rendered listing when path ends with '/index.html' or '/'" ) } )
     @HEAD
     @Path( "/{path: (.*)}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doHead( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                             final @PathParam( "path" ) String path,
                             final @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly, final @Context UriInfo uriInfo,
@@ -132,6 +134,7 @@ public class MavenContentAccessResource
                           description = "Rendered content listing (when path ends with '/index.html' or '/') or Content stream" ) } )
     @GET
     @Path( "/{path: (.*)}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            final @PathParam( "path" ) String path, @Context final UriInfo uriInfo,
                            @Context final HttpServletRequest request )

--- a/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/NPMContentAccessResource.java
+++ b/src/main/java/org/commonjava/indy/service/ui/jaxrs/content/NPMContentAccessResource.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.service.ui.jaxrs.content;
 
+import io.quarkus.vertx.http.Uncompressed;
 import org.commonjava.indy.service.ui.client.content.NPMContentAccessServiceClient;
 import org.commonjava.indy.service.ui.models.repository.StoreType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -132,6 +133,7 @@ public class NPMContentAccessResource
             @APIResponse( responseCode = "200", description = "Header metadata for package metadata content" ), } )
     @HEAD
     @Path( "/{packageName}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doHead( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                             final @PathParam( "packageName" ) String packageName,
                             final @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly, @Context final UriInfo uriInfo,
@@ -153,6 +155,7 @@ public class NPMContentAccessResource
             @APIResponse( responseCode = "200", description = "Header metadata for tarball content" ), } )
     @HEAD
     @Path( "/{packageName}/{versionTarball: (.*)}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doHead( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                             final @PathParam( "packageName" ) String packageName,
                             final @PathParam( "versionTarball" ) String versionTarball,
@@ -178,6 +181,7 @@ public class NPMContentAccessResource
                           description = "Rendered content listing or Content stream" ) } )
     @GET
     @Path( "/{packageName}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            final @PathParam( "packageName" ) String packageName, @Context final UriInfo uriInfo,
                            @Context final HttpServletRequest request )
@@ -200,6 +204,7 @@ public class NPMContentAccessResource
                           description = "Content stream" ), } )
     @GET
     @Path( "/{packageName}/{versionTarball: (.*)}" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            final @PathParam( "packageName" ) String packageName,
                            final @PathParam( "versionTarball" ) String versionTarball, @Context final UriInfo uriInfo,
@@ -219,6 +224,7 @@ public class NPMContentAccessResource
                   description = "Rendered content listing or Content stream" )
     @GET
     @Path( "/" )
+    @Uncompressed // We should never compress this because it is often used by cli tools or other non-browser tools
     public Response doGet( final @PathParam( "type" ) String type, final @PathParam( "name" ) String name,
                            @Context final UriInfo uriInfo, @Context final HttpServletRequest request )
     {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,16 +3,12 @@ quarkus:
     name: "Indy"
   package:
     type: uber-jar
-  resteasy:
-    gzip:
-      enabled: true
-      max-input: 64M
   http:
     port: 8080
     read-timeout: 30m
-    enable-compression: true
+#    enable-compression: true
     limits:
-      max-body-size: 500M
+      max-body-size: 1000M
     auth:
       permission:
         authenticated:
@@ -29,7 +25,6 @@ quarkus:
           paths: "/api/*"
           policy: permit
           methods: HEAD,GET
-
   oidc:
     enabled: true
 #    auth-server-url: "http://localhost:8180/realms/test"


### PR DESCRIPTION
  There are many non-browser tools which will use the REST APIs, and
  many of them are not supporting http-compression. So we should disable
  this.