### PR TITLE
Remove the usage of disable timeout to decide if repo is disabled in listing

### DIFF
--- a/src/main/webui/src/app/components/content/common/StoreListingWidget.jsx
+++ b/src/main/webui/src/app/components/content/common/StoreListingWidget.jsx
@@ -94,16 +94,15 @@ StoreNameSection.propTypes = {
   storeClass: PropTypes.string
 };
 
-const StoreListingWidget = ({storeList, disableMap, storeType}) => {
+const StoreListingWidget = ({storeList, storeType}) => {
   const listing = storeList;
-  const disMap = disableMap;
   if(listing && listing.length >0){
     return (
       <div className="content-panel">
         <div className="store-listing">
           {
             listing.map(store => {
-              const storeClass = Utils.isDisabled(store.key, disMap)? "disabled-store":"enabled-store";
+              const storeClass = store.disabled? "disabled-store":"enabled-store";
               return (
                 <div key={store.key} className="store-listing-item">
                   <StoreNameSection store={store} storeClass={storeClass} />
@@ -137,7 +136,6 @@ const StoreListingWidget = ({storeList, disableMap, storeType}) => {
 
 StoreListingWidget.propTypes = {
   storeList: PropTypes.array,
-  disableMap: PropTypes.object,
   storeType: PropTypes.string
 };
 

--- a/src/main/webui/src/app/components/content/common/StoreListingWidget.test.jsx
+++ b/src/main/webui/src/app/components/content/common/StoreListingWidget.test.jsx
@@ -37,9 +37,8 @@ describe('StoreListingWidget tests', () => {
        url: "https://maven.repository.redhat.com/ga/",
        description: "Red Hat maven repository"},
     ];
-    const mockDisableMap = {};
     render(<MemoryRouter>
-    <StoreListingWidget storeList={mockRemoteStoreList} disableMap={mockDisableMap} storeType="remote"/>
+    <StoreListingWidget storeList={mockRemoteStoreList} storeType="remote"/>
     </MemoryRouter>);
 
     // Testing LocalURLSection

--- a/src/main/webui/src/app/components/content/group/GroupList.jsx
+++ b/src/main/webui/src/app/components/content/group/GroupList.jsx
@@ -24,7 +24,7 @@ import {LoadingSpiner} from "../common/LoadingSpiner.jsx";
 import {Utils} from "#utils/AppUtils.js";
 import {IndyRest} from "#utils/RestClient.js";
 
-const {storeRes, disableRes} = IndyRest;
+const {storeRes} = IndyRest;
 
 const handlers = {
   handleDebug: (event, setState) => {
@@ -51,7 +51,6 @@ export default function GroupList() {
   const [state, setState] = useState({
     rawList: [],
     listing: [],
-    disabledMap: {},
     enableDebug: false,
     message: "",
   });
@@ -62,22 +61,13 @@ export default function GroupList() {
     (async () => {
       const res = await storeRes.getStores(packageType, "group");
       if (res.success) {
-        const timeoutRes = await disableRes.getAllStoreTimeout();
-        let disabledMap = {};
-        if (timeoutRes.success) {
-          const timeoutData = timeoutRes.result;
-          disabledMap = Utils.setDisableMap(timeoutData);
-        } else {
-          Utils.logMessage(`disable timeout get failed in group listing! Error reason: ${timeoutRes.error.message}`,);
-        }
         let data = res.result;
         if (typeof data === "string") {
           data = JSON.parse(data);
         }
         setState({
           rawList: data.items,
-          listing: data.items,
-          disabledMap,
+          listing: data.items
         });
       } else {
         setState({
@@ -106,7 +96,6 @@ export default function GroupList() {
       {state.listing ?
         <StoreListingWidget
           storeList={state.listing}
-          disableMap={state.disabledMap}
           storeType="group"
         />
        :

--- a/src/main/webui/src/app/components/content/hosted/HostedList.jsx
+++ b/src/main/webui/src/app/components/content/hosted/HostedList.jsx
@@ -24,7 +24,7 @@ import {LoadingSpiner} from "../common/LoadingSpiner.jsx";
 import {Utils} from "#utils/AppUtils.js";
 import {IndyRest} from "#utils/RestClient.js";
 
-const {storeRes, disableRes} = IndyRest;
+const {storeRes} = IndyRest;
 
 const handlers = {
   handleDebug: (event, setState) => {
@@ -51,7 +51,6 @@ export default function HostedList() {
   const [state, setState] = useState({
     rawList: [],
     listing: [],
-    disabledMap: {},
     enableDebug: false,
     message: "",
   });
@@ -62,22 +61,13 @@ export default function HostedList() {
     (async () => {
       const res = await storeRes.getStores(packageType, "hosted");
       if (res.success) {
-        const timeoutRes = await disableRes.getAllStoreTimeout();
-        let disabledMap = {};
-        if (timeoutRes.success) {
-          const timeoutData = timeoutRes.result;
-          disabledMap = Utils.setDisableMap(timeoutData);
-        } else {
-          Utils.logMessage(`disable timeout get failed in hosted listing! Error reason: ${timeoutRes.error.message}`,);
-        }
         let data = res.result;
         if (typeof data === "string") {
           data = JSON.parse(data);
         }
         setState({
           rawList: data.items,
-          listing: data.items,
-          disabledMap,
+          listing: data.items
         });
       } else {
         setState({
@@ -106,7 +96,6 @@ export default function HostedList() {
       {state.listing ?
         <StoreListingWidget
           storeList={state.listing}
-          disableMap={state.disabledMap}
           storeType="hosted"
         />
        :

--- a/src/main/webui/src/app/components/content/remote/RemoteList.jsx
+++ b/src/main/webui/src/app/components/content/remote/RemoteList.jsx
@@ -24,7 +24,7 @@ import {LoadingSpiner} from "../common/LoadingSpiner.jsx";
 import {Utils} from '#utils/AppUtils.js';
 import {IndyRest} from '#utils/RestClient.js';
 
-const {storeRes, disableRes} = IndyRest;
+const {storeRes} = IndyRest;
 
 const handlers = {
   handleDebug: (event, setState) => {
@@ -51,7 +51,6 @@ export default function RemoteList() {
   const [state, setState] = useState({
     rawList: [],
     listing: [],
-    disabledMap: {},
     enableDebug: false,
     message: ''
   });
@@ -62,22 +61,13 @@ export default function RemoteList() {
     (async ()=>{
       const res = await storeRes.getStores(packageType, "remote");
       if (res.success){
-        const timeoutRes = await disableRes.getAllStoreTimeout();
-        let disabledMap = {};
-        if (timeoutRes.success){
-          const timeoutData = timeoutRes.result;
-          disabledMap = Utils.setDisableMap(timeoutData);
-        }else{
-          Utils.logMessage(`disable timeout get failed in remote listing! Error reason: ${timeoutRes.error.message}`);
-        }
         let data = res.result;
         if(typeof data === 'string'){
           data = JSON.parse(data);
         }
         setState({
           rawList: data.items,
-          listing: data.items,
-          disabledMap
+          listing: data.items
         });
       }else{
         setState({
@@ -103,7 +93,7 @@ export default function RemoteList() {
       />
       {
       state.listing?
-      <StoreListingWidget storeList={state.listing} disableMap={state.disabledMap} storeType="remote" />:
+      <StoreListingWidget storeList={state.listing} storeType="remote" />:
       <div className="container-fluid">
         No content fetched!
       </div>


### PR DESCRIPTION
  As repo definition has "disabled" property, we can use it to decide if
  repo is disabled, so no need to do another API fetch of disable
  timeout to check in listing.