### PR TITLE
Revert "Make snapshot publish action working just on pr merging"

### DIFF
--- a/.github/workflows/merge-build.yml
+++ b/.github/workflows/merge-build.yml
@@ -24,7 +24,6 @@ on: [push]
 jobs:
   publish-snapshot:
     name: Build & push image
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This reverts commit 58315170050ba8c94746e2c3ea807f1690b7f98c.